### PR TITLE
CSV File name fixed for test_load_waypoint_name_to_coordinates_map.py

### DIFF
--- a/tests/test_load_waypoint_name_to_coordinates_map.py
+++ b/tests/test_load_waypoint_name_to_coordinates_map.py
@@ -11,7 +11,7 @@ def test_normal_file():
     Normal CSV file.
     """
     # Setup
-    normal_csv_file_path = pathlib.Path("test_csv", "test_normal_csv.csv")
+    normal_csv_file_path = pathlib.Path("tests/test_csv/test_normal_csv.csv")
     expected = {
         "WARG": (43.47323264522664, -80.54011639872981),
         "University of Waterloo Station for 301 ION": (43.4735247614021, -80.54144667502672),

--- a/tests/test_load_waypoint_name_to_coordinates_map.py
+++ b/tests/test_load_waypoint_name_to_coordinates_map.py
@@ -11,7 +11,7 @@ def test_normal_file():
     Normal CSV file.
     """
     # Setup
-    normal_csv_file_path = pathlib.Path("tests/test_csv/test_normal_csv.csv")
+    normal_csv_file_path = pathlib.Path("tests", "test_csv", "test_normal_csv.csv")
     expected = {
         "WARG": (43.47323264522664, -80.54011639872981),
         "University of Waterloo Station for 301 ION": (43.4735247614021, -80.54144667502672),


### PR DESCRIPTION
I noticed that one of the test cases was failing for `test_load_waypoint_name_to_coordinates_map.py`. I'm not sure if it varies based on python version (I'm using Python 3.8.10) but the test was failing on my laptop as well as the WARG laptop. Just a simple fix with the path of the csv filed updated.