### PR TITLE
Fixed bug by removing delay in infinite while loop

### DIFF
--- a/modules/mission_time_condition.py
+++ b/modules/mission_time_condition.py
@@ -61,7 +61,7 @@ class MissionTimeCondition(condition.Condition):
             Frequency to print time elapsed to the console.
         """
         time_elapsed = int(time.time() - self.start_time)
-        
+
         if time_elapsed % frequency == 0 and time_elapsed != self.previous_time_elapsed:
             self.previous_time_elapsed = time_elapsed
             print(f"Elapsed time (s): {time_elapsed}")

--- a/modules/mission_time_condition.py
+++ b/modules/mission_time_condition.py
@@ -42,6 +42,7 @@ class MissionTimeCondition(condition.Condition):
         self.start_time = start_time
         self.maximum_flight_time = maximum_flight_time
         self.lap_time = 0
+        self.previous_time_elapsed = -1
 
     def evaluate_condition(self) -> bool:
         """
@@ -53,12 +54,17 @@ class MissionTimeCondition(condition.Condition):
 
         return True
 
-    def output_time_elapsed(self) -> None:
+    def output_time_elapsed(self, frequency: int) -> None:
         """
         Outputs the total time elapsed during the mission.
+        frequency: int
+            Frequency to print time elapsed to the console.
         """
-        current_time = time.time()
-        print(f"Elapsed time (s): {current_time - self.start_time}")
+        time_elapsed = int(time.time() - self.start_time)
+        
+        if time_elapsed % frequency == 0 and time_elapsed != self.previous_time_elapsed:
+            self.previous_time_elapsed = time_elapsed
+            print(f"Elapsed time (s): {time_elapsed}")
 
     def update_lap_time(self, lap_time: float) -> None:
         """

--- a/path_2024_task_1.py
+++ b/path_2024_task_1.py
@@ -21,7 +21,7 @@ from modules import upload_commands
 TAKEOFF_WAYPOINT_FILE_PATH = pathlib.Path("2024", "waypoints", "takeoff_waypoint_task_1.csv")
 LAP_WAYPOINTS_FILE_PATH = pathlib.Path("2024", "waypoints", "lap_waypoints_task_1.csv")
 CONNECTION_ADDRESS = "tcp:localhost:14550"
-DELAY = 30  # seconds
+PRINT_FREQUENCY = 30  # seconds
 MAXIMUM_FLIGHT_TIME = 1800  # in seconds
 TAKEOFF_ALTITUDE = 0  # metres
 ALPHA_WAYPOINT_ALTITUDE = 100  # metres
@@ -161,7 +161,7 @@ def main() -> int:
                     print("\n--------------------------------------------------------")
                     print(f"Starting lap {lap_counter}")
                     print("--------------------------------------------------------")
-                    time_condition.output_time_elapsed()
+                    time_condition.output_time_elapsed(PRINT_FREQUENCY)
 
                     # Disable flag since starting lap time is recorded
                     starting_lap = False
@@ -171,7 +171,7 @@ def main() -> int:
                     lap_time = lap_end_time - lap_start_time
 
                     # Log lap and time data
-                    time_condition.output_time_elapsed()
+                    time_condition.output_time_elapsed(PRINT_FREQUENCY)
                     print("--------------------------------------------------------")
                     print(f"Lap {lap_counter} start time (s): {lap_start_time}")
                     print(f"Lap {lap_counter} end time (s): {lap_end_time}")
@@ -190,17 +190,15 @@ def main() -> int:
                     lap_start_time, lap_end_time = 0, 0
             else:
                 # Log time data
-                time_condition.output_time_elapsed()
+                time_condition.output_time_elapsed(PRINT_FREQUENCY)
         else:
             # Log time data
-            time_condition.output_time_elapsed()
+            time_condition.output_time_elapsed(PRINT_FREQUENCY)
             # Enable flag so when lap start waypoint is reached again, lap time can be calculated
             starting_lap = True
 
         if should_return_to_launch:
             break
-
-        time.sleep(DELAY)
 
     # Force early RTL
     drone.mode = dronekit.VehicleMode("RTL")

--- a/tests/integration/test_check_stop_condition.py
+++ b/tests/integration/test_check_stop_condition.py
@@ -80,7 +80,7 @@ def main() -> int:
         if should_return_to_launch:
             break
 
-        check_time_condition.output_time_elapsed()
+        check_time_condition.output_time_elapsed(30)
 
         time.sleep(DELAY)
 


### PR DESCRIPTION
## Fixed bug by removing delay in infinite while loop

**Why is this change needed**
- There used to be a delay of 30 seconds in the infinite while loop
  - I did this because if we want to sample something at 1 minute, we need to sample it at double the frequency (30 seconds)
  - This causes an issue since when the code is delayed at 30 seconds it might miss the switch to the next lap 
  - In the WRESTRC waypoints case the switch to the start of lap takes only 5 seconds so it would completely miss the start of the next lap

**Key Changes**
- Got rid of the delay in the infinite while loop
  - This ensures that we time the lap exactly when it switches so it is more accurate 😄 
 - Had to change the `output_time_elapsed` function so it doesn't spam the console (added a print frequency parameter)
 
**Testing**
- Tested with Mission Planner simulator connected to RealFlight on ***WRESTRC Waypoints***
- Have not tested on competition waypoints but will do so after flight test