### PR TITLE
Flightcontroller wrapper

### DIFF
--- a/modules/waypoints_to_commands.py
+++ b/modules/waypoints_to_commands.py
@@ -5,7 +5,7 @@ Function to convert list of waypoints to dronekit commands.
 from . import generate_command
 from .common.modules import location_global
 from .common.modules import position_global_relative_altitude
-from .common.modules.mavlink import dronekit
+from .common.modules.mavlink import flight_controller
 
 
 ACCEPT_RADIUS = 5.0  # metres
@@ -13,7 +13,7 @@ ACCEPT_RADIUS = 5.0  # metres
 
 def waypoints_to_commands(
     waypoints: list[location_global.LocationGlobal], altitude: float
-) -> tuple[True, list[dronekit.Command]] | tuple[False, None]:
+) -> tuple[True, list[flight_controller.dronekit.Command]] | tuple[False, None]:
     """
     Convert list of waypoints to dronekit commands.
 
@@ -39,7 +39,7 @@ def waypoints_to_commands(
 
 def waypoints_with_altitude_to_commands(
     waypoints: list[position_global_relative_altitude.PositionGlobalRelativeAltitude],
-) -> tuple[True, list[dronekit.Command]] | tuple[False, None]:
+) -> tuple[True, list[flight_controller.dronekit.Command]] | tuple[False, None]:
     """
     Convert list of waypoints to dronekit commands.
 

--- a/modules/waypoints_to_spline_commands.py
+++ b/modules/waypoints_to_spline_commands.py
@@ -4,12 +4,12 @@ Function to convert list of waypoints a list of spline waypoint dronekit command
 
 from . import generate_command
 from .common.modules import location_global
-from .common.modules.mavlink import dronekit
+from .common.modules.mavlink import flight_controller
 
 
 def waypoints_to_spline_commands(
     waypoints: list[location_global.LocationGlobal], altitude: float
-) -> tuple[True, list[dronekit.Command]] | tuple[False, None]:
+) -> tuple[True, list[flight_controller.dronekit.Command]] | tuple[False, None]:
     """
     Convert list of waypoints to a list of spline waypoint dronekit commands.
     Spline waypoint dronekit commands fly to the target waypoint following a spline path

--- a/tests/integration/test_check_stop_condition.py
+++ b/tests/integration/test_check_stop_condition.py
@@ -56,7 +56,7 @@ def main() -> int:
         print("Unable to add takeoff and landing commands.")
         return -1
 
-    result = flight_controller.FlightController.upload_commands(commands_with_takeoff_landing)
+    result = controller.upload_commands(commands_with_takeoff_landing)
     if not result:
         print("Unable to upload commands.")
         return -1

--- a/tests/integration/test_check_stop_condition.py
+++ b/tests/integration/test_check_stop_condition.py
@@ -57,7 +57,7 @@ def main() -> int:
         return -1
 
     result = flight_controller.FlightController.upload_commands(
-        controller.drone, commands_with_takeoff_landing, DRONE_TIMEOUT
+        commands_with_takeoff_landing
     )
     if not result:
         print("Unable to upload commands.")

--- a/tests/integration/test_check_stop_condition.py
+++ b/tests/integration/test_check_stop_condition.py
@@ -56,9 +56,7 @@ def main() -> int:
         print("Unable to add takeoff and landing commands.")
         return -1
 
-    result = flight_controller.FlightController.upload_commands(
-        commands_with_takeoff_landing
-    )
+    result = flight_controller.FlightController.upload_commands(commands_with_takeoff_landing)
     if not result:
         print("Unable to upload commands.")
         return -1

--- a/tests/integration/test_check_stop_condition.py
+++ b/tests/integration/test_check_stop_condition.py
@@ -7,7 +7,6 @@ import time
 from modules import add_takeoff_and_landing_command
 from modules import condition_evaluator
 from modules import mission_time_condition
-from modules import upload_commands
 from modules import waypoints_to_commands
 from modules.common.modules import location_global
 from modules.common.modules.mavlink import flight_controller
@@ -57,7 +56,7 @@ def main() -> int:
         print("Unable to add takeoff and landing commands.")
         return -1
 
-    result = upload_commands.upload_commands(
+    result = flight_controller.FlightController.upload_commands(
         controller.drone, commands_with_takeoff_landing, DRONE_TIMEOUT
     )
     if not result:

--- a/tests/unit/test_add_takeoff_and_landing_command.py
+++ b/tests/unit/test_add_takeoff_and_landing_command.py
@@ -9,7 +9,7 @@ import pytest
 
 from modules import add_takeoff_and_landing_command
 from modules import generate_command
-from modules.common.modules.mavlink import dronekit
+from modules.common.modules.mavlink import flight_controller
 
 
 ALTITUDE = 50.0  # metres
@@ -26,7 +26,7 @@ SECOND_WAYPOINT_LONGITUDE = -73.987
 
 
 @pytest.fixture
-def non_empty_commands() -> "list[dronekit.Command]":  # type: ignore
+def non_empty_commands() -> "list[flight_controller.dronekit.Command]":  # type: ignore
     """
     Fixture for a list of commands.
     """
@@ -42,7 +42,7 @@ def non_empty_commands() -> "list[dronekit.Command]":  # type: ignore
 
 
 @pytest.fixture
-def empty_commands() -> "list[dronekit.Command]":  # type: ignore
+def empty_commands() -> "list[flight_controller.dronekit.Command]":  # type: ignore
     """
     Fixture for an empty list of commands.
     """
@@ -51,8 +51,8 @@ def empty_commands() -> "list[dronekit.Command]":  # type: ignore
 
 
 def assert_expected_takeoff_and_landing_commands(
-    commands_actual: "list[dronekit.Command]",
-    commands_expected: "list[dronekit.Command]",
+    commands_actual: "list[flight_controller.dronekit.Command]",
+    commands_expected: "list[flight_controller.dronekit.Command]",
     altitude: float,
 ) -> None:
     """
@@ -62,14 +62,14 @@ def assert_expected_takeoff_and_landing_commands(
 
     # Test takeoff command
     takeoff_command = commands_actual[0]
-    assert isinstance(takeoff_command, dronekit.Command)
+    assert isinstance(takeoff_command, flight_controller.dronekit.Command)
     assert takeoff_command.frame == mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT
     assert takeoff_command.command == mavutil.mavlink.MAV_CMD_NAV_TAKEOFF
     assert takeoff_command.z == altitude
 
     # Test landing command
     landing_command = commands_actual[-1]
-    assert isinstance(landing_command, dronekit.Command)
+    assert isinstance(landing_command, flight_controller.dronekit.Command)
     assert landing_command.frame == mavutil.mavlink.MAV_FRAME_GLOBAL
     assert landing_command.command == mavutil.mavlink.MAV_CMD_NAV_LAND
 
@@ -79,7 +79,7 @@ def assert_expected_takeoff_and_landing_commands(
 
 
 def test_add_takeoff_and_landing_on_empty_commands(
-    empty_commands: "list[dronekit.Command]",
+    empty_commands: "list[flight_controller.dronekit.Command]",
 ) -> None:
     """
     Tests functionality correctness of add_takeoff_and_landing_command on empty list of commands.
@@ -93,7 +93,7 @@ def test_add_takeoff_and_landing_on_empty_commands(
 
 
 def test_add_takeoff_and_landing_on_nonempty_commands(
-    non_empty_commands: "list[dronekit.Command]",
+    non_empty_commands: "list[flight_controller.dronekit.Command]",
 ) -> None:
     """
     Tests functionality correctness of add_takeoff_and_landing_command on non-empty list of commands.

--- a/tests/unit/test_add_takeoff_and_rtl_command.py
+++ b/tests/unit/test_add_takeoff_and_rtl_command.py
@@ -78,7 +78,9 @@ def assert_expected_takeoff_and_rtl_commands(
     assert commands_actual[1:-1] == commands_expected
 
 
-def test_add_takeoff_and_rtl_on_empty_commands(empty_commands: "list[flight_controller.dronekit.Command]") -> None:
+def test_add_takeoff_and_rtl_on_empty_commands(
+    empty_commands: "list[flight_controller.dronekit.Command]",
+) -> None:
     """
     Tests functionality correctness of add_takeoff_and_rtl_command on empty list of commands.
     """

--- a/tests/unit/test_add_takeoff_and_rtl_command.py
+++ b/tests/unit/test_add_takeoff_and_rtl_command.py
@@ -9,7 +9,7 @@ import pytest
 
 from modules import add_takeoff_and_rtl_command
 from modules import generate_command
-from modules.common.modules.mavlink import dronekit
+from modules.common.modules.mavlink import flight_controller
 
 
 ALTITUDE = 50.0  # metres
@@ -26,7 +26,7 @@ SECOND_WAYPOINT_LONGITUDE = -73.987
 
 
 @pytest.fixture
-def non_empty_commands() -> "list[dronekit.Command]":  # type: ignore
+def non_empty_commands() -> "list[flight_controller.dronekit.Command]":  # type: ignore
     """
     Fixture for a list of commands.
     """
@@ -42,7 +42,7 @@ def non_empty_commands() -> "list[dronekit.Command]":  # type: ignore
 
 
 @pytest.fixture
-def empty_commands() -> "list[dronekit.Command]":  # type: ignore
+def empty_commands() -> "list[flight_controller.dronekit.Command]":  # type: ignore
     """
     Fixture for an empty list of commands.
     """
@@ -51,8 +51,8 @@ def empty_commands() -> "list[dronekit.Command]":  # type: ignore
 
 
 def assert_expected_takeoff_and_rtl_commands(
-    commands_actual: "list[dronekit.Command]",
-    commands_expected: "list[dronekit.Command]",
+    commands_actual: "list[flight_controller.dronekit.Command]",
+    commands_expected: "list[flight_controller.dronekit.Command]",
     altitude: float,
 ) -> None:
     """
@@ -62,14 +62,14 @@ def assert_expected_takeoff_and_rtl_commands(
 
     # Test takeoff command
     takeoff_command = commands_actual[0]
-    assert isinstance(takeoff_command, dronekit.Command)
+    assert isinstance(takeoff_command, flight_controller.dronekit.Command)
     assert takeoff_command.frame == mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT
     assert takeoff_command.command == mavutil.mavlink.MAV_CMD_NAV_TAKEOFF
     assert takeoff_command.z == altitude
 
     # Test RTL command
     rtl_command = commands_actual[-1]
-    assert isinstance(rtl_command, dronekit.Command)
+    assert isinstance(rtl_command, flight_controller.dronekit.Command)
     assert rtl_command.frame == mavutil.mavlink.MAV_FRAME_GLOBAL
     assert rtl_command.command == mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH
 
@@ -78,7 +78,7 @@ def assert_expected_takeoff_and_rtl_commands(
     assert commands_actual[1:-1] == commands_expected
 
 
-def test_add_takeoff_and_rtl_on_empty_commands(empty_commands: "list[dronekit.Command]") -> None:
+def test_add_takeoff_and_rtl_on_empty_commands(empty_commands: "list[flight_controller.dronekit.Command]") -> None:
     """
     Tests functionality correctness of add_takeoff_and_rtl_command on empty list of commands.
     """
@@ -91,7 +91,7 @@ def test_add_takeoff_and_rtl_on_empty_commands(empty_commands: "list[dronekit.Co
 
 
 def test_add_takeoff_and_rtl_on_nonempty_commands(
-    non_empty_commands: "list[dronekit.Command]",
+    non_empty_commands: "list[flight_controller.dronekit.Command]",
 ) -> None:
     """
     Tests functionality correctness of add_takeoff_and_rtl_command on non-empty list of commands.


### PR DESCRIPTION
Added flightcontroller to `waypoints_to_commands.py` , `waypoints_to_spline_commands.py`, `tests/integration/test_check_stop_condition.py`, `tests/unit/test_add_takeoff_and_rtl_commands.py` and `tests/unit/test_add_takeoff_and_landing_command.py`.