### PR TITLE
Migrate some files from Dronekit to FlightController

### DIFF
--- a/connection_check.py
+++ b/connection_check.py
@@ -22,11 +22,7 @@ def write_test_mission(drone: flight_controller.FlightController) -> bool:
     Creates and sends a hardcoded test mission to the drone.
     """
 
-    result = drone.drone.commands.clear()
-
-    if not result:
-        print("ERROR: Could not clear mission.")
-        return False
+    drone.drone.commands.clear()
 
     # Create and upload commands
     result = drone.insert_waypoint(0, -35.3632610, 149.1691446, ALTITUDE)

--- a/connection_check.py
+++ b/connection_check.py
@@ -23,64 +23,24 @@ def write_test_mission(drone: flight_controller.FlightController) -> bool:
     """
     Creates and sends a hardcoded test mission to the drone.
     """
-    commands = []
-
-    # Create and add commands
-    command0 = flight_controller.dronekit.Command(
-        0,
-        0,
-        0,
-        mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
-        mavutil.mavlink.MAV_CMD_NAV_WAYPOINT,
-        0,
-        0,
-        0,  # param1
-        10,
-        0,
-        0,
-        -35.3632610,
-        149.1691446,
-        ALTITUDE,
-    )
-
-    commands.append(command0)
-
-    command1 = flight_controller.dronekit.Command(
-        0,
-        0,
-        0,
-        mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
-        mavutil.mavlink.MAV_CMD_NAV_WAYPOINT,
-        0,
-        0,
-        0,  # param1
-        10,
-        10,
-        0,
-        -35.3603736,
-        149.1689944,
-        ALTITUDE,
-    )
-
-    commands.append(command1)
-
-    # Get the set of commands from the drone
-    result, command_sequence = drone.download_commands()
+    
+    result = drone.drone.commands.clear()
 
     if not result:
-        print("ERROR: Could not download commands.")
+        print("ERROR: Could not clear mission.")
         return False
 
-    command_sequence.clear()
-
-    for command in commands:
-        command_sequence.add(command)
-
-    # Upload commands to drone
-    result = drone.upload_commands(command_sequence)
+    # Create and upload commands
+    result = drone.insert_waypoint(0, -35.3632610, 149.1691446, ALTITUDE)
 
     if not result:
-        print("ERROR: Could not upload commands.")
+        print("ERROR: Could not upload command 0.")
+        return False
+
+    result = drone.insert_waypoint(1, -35.3603736, 149.1689944, ALTITUDE)
+
+    if not result:
+        print("ERROR: Could not upload command 1.")
         return False
 
     return True
@@ -106,9 +66,21 @@ def read_data(drone: flight_controller.FlightController) -> bool:
     print(odometry.orientation.roll)
     print(odometry.orientation.yaw)
 
+    result, commands = drone.download_commands()
+
+    if not result:
+        print("ERROR: Could not get commands.")
+        return False
+    
+    result, next_waypoint = drone.get_next_waypoint()
+
+    if not result:
+        print("ERROR: Could not get next waypoint.")
+        return False
+
     print("Command information:")
-    print("Waypoint total count: " + str(drone.drone.commands.count))
-    print("Next waypoint index: " + str(drone.drone.commands.next))
+    print("Waypoint total count: " + str(commands.count()))
+    print("Next waypoint index: " + str(drone.get_next_waypoint().index()))
 
     return True
 

--- a/connection_check.py
+++ b/connection_check.py
@@ -1,12 +1,10 @@
 """
-For testing MAVLink connection with DroneKit-Python.
+For testing MAVLink connection with FlightController.
 """
 
 import time
 
-from pymavlink import mavutil
-
-from modules.common.modules.mavlink import dronekit
+from modules.common.modules.mavlink import flight_controller
 
 
 # Set these to test what you want to test
@@ -19,106 +17,84 @@ CONNECTION_ADDRESS = "tcp:localhost:14550"
 ALTITUDE = 40  # metres
 
 
-def write_test_mission(drone: dronekit.Vehicle) -> bool:
+def write_test_mission(drone: flight_controller.FlightController) -> bool:
     """
     Creates and sends a hardcoded test mission to the drone.
     """
-    commands = []
 
-    # Create and add commands
-    command0 = dronekit.Command(
-        0,
-        0,
-        0,
-        mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
-        mavutil.mavlink.MAV_CMD_NAV_WAYPOINT,
-        0,
-        0,
-        0,  # param1
-        10,
-        0,
-        0,
-        -35.3632610,
-        149.1691446,
-        ALTITUDE,
-    )
+    result = drone.drone.commands.clear()
 
-    commands.append(command0)
+    if not result:
+        print("ERROR: Could not clear mission.")
+        return False
 
-    command1 = dronekit.Command(
-        0,
-        0,
-        0,
-        mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
-        mavutil.mavlink.MAV_CMD_NAV_WAYPOINT,
-        0,
-        0,
-        0,  # param1
-        10,
-        10,
-        0,
-        -35.3603736,
-        149.1689944,
-        ALTITUDE,
-    )
+    # Create and upload commands
+    result = drone.insert_waypoint(0, -35.3632610, 149.1691446, ALTITUDE)
 
-    commands.append(command1)
+    if not result:
+        print("ERROR: Could not upload command 0.")
+        return False
 
-    # Get the set of commands from the drone
-    command_sequence = drone.commands
-    command_sequence.download()
-    command_sequence.wait_ready()
-    command_sequence.clear()
-    for command in commands:
-        command_sequence.add(command)
+    result = drone.insert_waypoint(1, -35.3603736, 149.1689944, ALTITUDE)
 
-    # Upload commands to drone
-    command_sequence.upload()
+    if not result:
+        print("ERROR: Could not upload command 1.")
+        return False
 
     return True
 
 
-def read_data(drone: dronekit.Vehicle) -> bool:
+def read_data(drone: flight_controller.FlightController) -> bool:
     """
     Prints drone telemetry and mission status.
     """
+    result, odometry = drone.get_odometry()
+
+    if not result:
+        print("ERROR: Could not get odometry.")
+        return False
+
+    print("Odometry:")
+    print("Position:")
+
     print("------")
     print("Position:")
-    print(drone.location.global_frame.alt)
-    print(drone.location.global_frame.lat)
-    print(drone.location.global_frame.lon)
+    print(odometry.position.altitude)
+    print(odometry.position.latitude)
+    print(odometry.position.longitude)
     print("Attitude:")
-    print(drone.attitude.pitch)
-    print(drone.attitude.roll)
-    print(drone.attitude.yaw)
-
-    command_sequence = drone.commands
-
-    command_sequence.download()
-    command_sequence.wait_ready()
+    print(odometry.orientation.pitch)
+    print(odometry.orientation.roll)
+    print(odometry.orientation.yaw)
 
     print("Command information:")
-    print("Waypoint total count: " + str(command_sequence.count))
-    print("Next waypoint index: " + str(command_sequence.next))
+    print("Waypoint total count: " + str(drone.drone.commands.count))
+    print("Next waypoint index: " + str(drone.drone.commands.next))
+
+    return True
 
 
 def main() -> int:
     """
     Main function.
     """
-    # TODO: Fails when wait_ready=True, debugging why this is
-    # wait_ready=False is dangerous
-    dronekit_vehicle = dronekit.connect(CONNECTION_ADDRESS, wait_ready=False)
+    result, flight_controller_vehicle = flight_controller.FlightController.create(
+        CONNECTION_ADDRESS
+    )
+
+    if not result:
+        print("ERROR: Could not connect to the flight controller.")
+        return -1
 
     if WRITE_TEST:
-        write_test_mission(dronekit_vehicle)
+        write_test_mission(flight_controller_vehicle)
 
     if READ_TEST:
         for _ in range(0, 40):
-            read_data(dronekit_vehicle)
+            read_data(flight_controller_vehicle)
             time.sleep(0.5)
 
-    dronekit_vehicle.close()
+    flight_controller_vehicle.close()
 
     return 0
 

--- a/connection_check.py
+++ b/connection_check.py
@@ -79,9 +79,9 @@ def read_data(drone: flight_controller.FlightController) -> bool:
     print("Command information:")
     print("Waypoint total count: " + str(len(commands)))
     print("Next waypoint coordinates:")
-    print("Altitude: " + next_waypoint.altitude)
-    print("Latitude: " + next_waypoint.latitude)
-    print("Longitude: " + next_waypoint.longitude)
+    print("Altitude: " + str(next_waypoint.altitude))
+    print("Latitude: " + str(next_waypoint.latitude))
+    print("Longitude: " + str(next_waypoint.longitude))
     print("------")
     return True
 

--- a/connection_check.py
+++ b/connection_check.py
@@ -4,6 +4,8 @@ For testing MAVLink connection with FlightController.
 
 import time
 
+from pymavlink import mavutil
+
 from modules.common.modules.mavlink import flight_controller
 
 
@@ -21,24 +23,64 @@ def write_test_mission(drone: flight_controller.FlightController) -> bool:
     """
     Creates and sends a hardcoded test mission to the drone.
     """
+    commands = []
 
-    result = drone.drone.commands.clear()
+    # Create and add commands
+    command0 = flight_controller.dronekit.Command(
+        0,
+        0,
+        0,
+        mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+        mavutil.mavlink.MAV_CMD_NAV_WAYPOINT,
+        0,
+        0,
+        0,  # param1
+        10,
+        0,
+        0,
+        -35.3632610,
+        149.1691446,
+        ALTITUDE,
+    )
+
+    commands.append(command0)
+
+    command1 = flight_controller.dronekit.Command(
+        0,
+        0,
+        0,
+        mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+        mavutil.mavlink.MAV_CMD_NAV_WAYPOINT,
+        0,
+        0,
+        0,  # param1
+        10,
+        10,
+        0,
+        -35.3603736,
+        149.1689944,
+        ALTITUDE,
+    )
+
+    commands.append(command1)
+
+    # Get the set of commands from the drone
+    result, command_sequence = drone.download_commands()
 
     if not result:
-        print("ERROR: Could not clear mission.")
+        print("ERROR: Could not download commands.")
         return False
 
-    # Create and upload commands
-    result = drone.insert_waypoint(0, -35.3632610, 149.1691446, ALTITUDE)
+    command_sequence.clear()
+
+    for command in commands:
+        command_sequence.add(command)
+
+    # Upload commands to drone
+    result = drone.upload_commands(command_sequence)
 
     if not result:
-        print("ERROR: Could not upload command 0.")
-        return False
-
-    result = drone.insert_waypoint(1, -35.3603736, 149.1689944, ALTITUDE)
-
-    if not result:
-        print("ERROR: Could not upload command 1.")
+        print("ERROR: Could not upload commands.")
         return False
 
     return True

--- a/connection_check.py
+++ b/connection_check.py
@@ -77,7 +77,7 @@ def read_data(drone: flight_controller.FlightController) -> bool:
         return False
 
     print("Command information:")
-    print("Waypoint total count: " + str(commands.count()))
+    print("Waypoint total count: " + str(len(commands)))
     print("Next waypoint index: " + str(commands.index(next_waypoint)))
 
     return True

--- a/connection_check.py
+++ b/connection_check.py
@@ -78,7 +78,7 @@ def read_data(drone: flight_controller.FlightController) -> bool:
 
     print("Command information:")
     print("Waypoint total count: " + str(commands.count()))
-    print("Next waypoint index: " + str(next_waypoint))
+    print("Next waypoint index: " + str(commands.index(next_waypoint)))
 
     return True
 

--- a/connection_check.py
+++ b/connection_check.py
@@ -78,8 +78,11 @@ def read_data(drone: flight_controller.FlightController) -> bool:
 
     print("Command information:")
     print("Waypoint total count: " + str(len(commands)))
-    print("Next waypoint index: " + str(commands.index(next_waypoint)))
-
+    print("Next waypoint coordinates:")
+    print("Altitude: " + next_waypoint.altitude)
+    print("Latitude: " + next_waypoint.latitude)
+    print("Longitude: " + next_waypoint.longitude)
+    print("------")
     return True
 
 

--- a/connection_check.py
+++ b/connection_check.py
@@ -4,8 +4,6 @@ For testing MAVLink connection with FlightController.
 
 import time
 
-from pymavlink import mavutil
-
 from modules.common.modules.mavlink import flight_controller
 
 
@@ -23,7 +21,7 @@ def write_test_mission(drone: flight_controller.FlightController) -> bool:
     """
     Creates and sends a hardcoded test mission to the drone.
     """
-    
+
     result = drone.drone.commands.clear()
 
     if not result:
@@ -71,7 +69,7 @@ def read_data(drone: flight_controller.FlightController) -> bool:
     if not result:
         print("ERROR: Could not get commands.")
         return False
-    
+
     result, next_waypoint = drone.get_next_waypoint()
 
     if not result:
@@ -80,7 +78,7 @@ def read_data(drone: flight_controller.FlightController) -> bool:
 
     print("Command information:")
     print("Waypoint total count: " + str(commands.count()))
-    print("Next waypoint index: " + str(drone.get_next_waypoint().index()))
+    print("Next waypoint index: " + str(next_waypoint.index()))
 
     return True
 

--- a/connection_check.py
+++ b/connection_check.py
@@ -96,9 +96,6 @@ def read_data(drone: flight_controller.FlightController) -> bool:
         print("ERROR: Could not get odometry.")
         return False
 
-    print("Odometry:")
-    print("Position:")
-
     print("------")
     print("Position:")
     print(odometry.position.altitude)

--- a/connection_check.py
+++ b/connection_check.py
@@ -78,7 +78,7 @@ def read_data(drone: flight_controller.FlightController) -> bool:
 
     print("Command information:")
     print("Waypoint total count: " + str(commands.count()))
-    print("Next waypoint index: " + str(next_waypoint.index()))
+    print("Next waypoint index: " + str(next_waypoint))
 
     return True
 

--- a/modules/add_takeoff_and_landing_command.py
+++ b/modules/add_takeoff_and_landing_command.py
@@ -3,27 +3,27 @@ Prefixes a takeoff command and suffixes a landing command to the end of the list
 """
 
 from . import generate_command
-from .common.modules.mavlink import dronekit
+from .common.modules.mavlink import flight_controller
 
 
 def add_takeoff_and_landing_command(
-    commands: "list[dronekit.Command]", altitude: float
-) -> "tuple[bool, list[dronekit.Command] | None]":
+    commands: "list[flight_controller.dronekit.Command]", altitude: float
+) -> "tuple[bool, list[flight_controller.dronekit.Command] | None]":
     """
-    Prepends a takeoff command and appends a landing command to a list of dronekit commands.
+    Prepends a takeoff command and appends a landing command to a list of flight_controller.dronekit commands.
 
     Parameters
     ----------
-    commands: list[dronekit.Command]
+    commands: list[flight_controller.dronekit.Command]
         Dronekit commands that can be sent to the drone.
     altitude: int
         Altitude in meters to command the drone to.
 
     Returns
     -------
-    tuple[bool, list[dronekit.Command] | None]:
+    tuple[bool, list[flight_controller.dronekit.Command] | None]:
         (False, None) if empty commands list,
-        (True, dronekit commands with takeoff and land commands that can be sent to the drone) otherwise.
+        (True, flight_controller.dronekit commands with takeoff and land commands that can be sent to the drone) otherwise.
     """
     if len(commands) == 0:
         return False, None

--- a/modules/add_takeoff_and_loiter_command.py
+++ b/modules/add_takeoff_and_loiter_command.py
@@ -3,22 +3,22 @@ Prefixes a takeoff command and suffixes a loiter command to the end of the list 
 """
 
 from . import generate_command
-from .common.modules.mavlink import dronekit
+from .common.modules.mavlink import flight_controller
 
 
 def add_takeoff_and_loiter_command(
-    commands: "list[dronekit.Command]",
+    commands: "list[flight_controller.dronekit.Command]",
     latitude: float,
     longitude: float,
     takeoff_altitude: float,
     loiter_altitude: float,
-) -> "tuple[bool, list[dronekit.Command] | None]":
+) -> "tuple[bool, list[flight_controller.dronekit.Command] | None]":
     """
     Prepends a takeoff command and appends a loiter command to a list of dronekit commands.
 
     Parameters
     ----------
-    commands: list[dronekit.Command]
+    commands: list[flight_controller.dronekit.Command]
         Dronekit commands that can be sent to the drone.
     latitude: float
         Loiter latitude values
@@ -29,7 +29,7 @@ def add_takeoff_and_loiter_command(
 
     Returns
     -------
-    tuple[bool, list[dronekit.Command] | None]:
+    tuple[bool, list[flight_controller.dronekit.Command] | None]:
         (False, None) if empty commands list,
         (True, dronekit commands with takeoff and land commands that can be sent to the drone) otherwise.
     """

--- a/modules/add_takeoff_and_rtl_command.py
+++ b/modules/add_takeoff_and_rtl_command.py
@@ -3,25 +3,25 @@ Prefixes a takeoff command and suffixes a RTL command to the end of the list of 
 """
 
 from . import generate_command
-from .common.modules.mavlink import dronekit
+from .common.modules.mavlink import flight_controller
 
 
 def add_takeoff_and_rtl_command(
-    commands: "list[dronekit.Command]", altitude: float
-) -> "tuple[bool, list[dronekit.Command] | None]":
+    commands: "list[flight_controller.dronekit.Command]", altitude: float
+) -> "tuple[bool, list[flight_controller.dronekit.Command] | None]":
     """
     Prepends a takeoff command and appends a RTL command to a list of dronekit commands.
 
     Parameters
     ----------
-    commands: list[dronekit.Command]
+    commands: list[flight_controller.dronekit.Command]
         Dronekit commands that can be sent to the drone.
     altitude: int
         Altitude in meters to command the drone to.
 
     Returns
     -------
-    tuple[bool, list[dronekit.Command] | None]:
+    tuple[bool, list[flight_controller.dronekit.Command] | None]:
         (False, None) if empty commands list,
         (True, dronekit commands with takeoff and land commands that can be sent to the drone) otherwise.
     """

--- a/modules/advanced_csv_to_commands.py
+++ b/modules/advanced_csv_to_commands.py
@@ -6,7 +6,7 @@ import pathlib
 
 from pymavlink import mavutil
 
-from .common.modules.mavlink import flight_controller
+from .common.modules.mavlink import dronekit
 
 
 VALID_FRAMES = {
@@ -91,7 +91,7 @@ def generate_command_advanced(
     if not check_validity(params, COMMAND_TO_PARAMETER_MATRIX[command_type]):
         return False, None
 
-    return True, flight_controller.dronekit.Command(
+    return True, dronekit.Command(
         0,
         0,
         0,

--- a/modules/advanced_csv_to_commands.py
+++ b/modules/advanced_csv_to_commands.py
@@ -6,7 +6,7 @@ import pathlib
 
 from pymavlink import mavutil
 
-from .common.modules.mavlink import dronekit
+from .common.modules.mavlink import flight_controller
 
 
 VALID_FRAMES = {
@@ -71,7 +71,7 @@ def generate_command_advanced(
     param5: float,
     param6: float,
     param7: float,
-) -> "tuple[bool,dronekit.Command | None]":
+) -> "tuple[bool,flight_controller.dronekit.Command | None]":
     """
     Parameters: See documentation: https://uwarg-docs.atlassian.net/wiki/spaces/CV/pages/2567274629/Encoded+MAVLink+commands
 
@@ -91,7 +91,7 @@ def generate_command_advanced(
     if not check_validity(params, COMMAND_TO_PARAMETER_MATRIX[command_type]):
         return False, None
 
-    return True, dronekit.Command(
+    return True, flight_controller.dronekit.Command(
         0,
         0,
         0,
@@ -111,7 +111,7 @@ def generate_command_advanced(
 
 def csv_to_commands_list(
     mission_file_path: pathlib.Path,
-) -> "tuple[bool, list[dronekit.Command] | None]":
+) -> "tuple[bool, list[flight_controller.dronekit.Command] | None]":
     """
     A method that reads a list of advanced commands from a csv file and generates a mission.
     Parameters:

--- a/modules/advanced_csv_to_commands.py
+++ b/modules/advanced_csv_to_commands.py
@@ -71,7 +71,7 @@ def generate_command_advanced(
     param5: float,
     param6: float,
     param7: float,
-) -> "tuple[bool,flight_controller.dronekit.Command | None]":
+) -> "tuple[bool,dronekit.Command | None]":
     """
     Parameters: See documentation: https://uwarg-docs.atlassian.net/wiki/spaces/CV/pages/2567274629/Encoded+MAVLink+commands
 
@@ -111,7 +111,7 @@ def generate_command_advanced(
 
 def csv_to_commands_list(
     mission_file_path: pathlib.Path,
-) -> "tuple[bool, list[flight_controller.dronekit.Command] | None]":
+) -> "tuple[bool, list[dronekit.Command] | None]":
     """
     A method that reads a list of advanced commands from a csv file and generates a mission.
     Parameters:

--- a/tests/unit/test_advanced_csv_to_commands.py
+++ b/tests/unit/test_advanced_csv_to_commands.py
@@ -6,7 +6,7 @@ import pathlib
 
 from modules import advanced_csv_to_commands
 from modules import generate_command
-from modules.common.modules.mavlink import dronekit
+from modules.common.modules.mavlink import flight_controller
 
 
 def test_normal_file() -> None:
@@ -36,7 +36,7 @@ def test_normal_file() -> None:
     assert len(mission) == len(expected_mission)
 
     for idx, command in enumerate(mission):
-        assert isinstance(command, dronekit.Command)
+        assert isinstance(command, flight_controller.dronekit.Command)
         assert command.frame == expected_mission[idx].frame
         assert command.command == expected_mission[idx].command
         assert command.param1 == expected_mission[idx].param1

--- a/tests/unit/test_waypoints_to_commands.py
+++ b/tests/unit/test_waypoints_to_commands.py
@@ -7,7 +7,7 @@ from pymavlink import mavutil
 from modules import waypoints_to_commands
 from modules.common.modules import location_global
 from modules.common.modules import position_global_relative_altitude
-from modules.common.modules.mavlink import dronekit
+from modules.common.modules.mavlink import flight_controller
 
 
 # Test functions use test fixture signature names and access class privates
@@ -68,7 +68,7 @@ def test_waypoints_to_commands() -> None:
         expected_latitude = waypoints[i].latitude
         expected_longitude = waypoints[i].longitude
 
-        assert isinstance(command, dronekit.Command)
+        assert isinstance(command, flight_controller.dronekit.Command)
         assert command.frame == mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT
         assert command.command == mavutil.mavlink.MAV_CMD_NAV_WAYPOINT
         assert command.param1 == 0
@@ -120,7 +120,7 @@ def test_waypoints_with_altitude_to_commands() -> None:
         expected_longitude = waypoints[i].longitude
         expected_altitude = waypoints[i].relative_altitude
 
-        assert isinstance(command, dronekit.Command)
+        assert isinstance(command, flight_controller.dronekit.Command)
         assert command.frame == mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT
         assert command.command == mavutil.mavlink.MAV_CMD_NAV_WAYPOINT
         assert command.param1 == 0

--- a/tests/unit/test_waypoints_to_spline_commands.py
+++ b/tests/unit/test_waypoints_to_spline_commands.py
@@ -6,7 +6,7 @@ from pymavlink import mavutil
 
 from modules import waypoints_to_spline_commands
 from modules.common.modules import location_global
-from modules.common.modules.mavlink import dronekit
+from modules.common.modules.mavlink import flight_controller
 
 
 # Test functions use test fixture signature names and access class privates
@@ -65,7 +65,7 @@ def test_waypoints_to_spline_commands() -> None:
     assert len(commands_actual) == len(waypoints)
 
     for i, command in enumerate(commands_actual):
-        assert isinstance(command, dronekit.Command)
+        assert isinstance(command, flight_controller.dronekit.Command)
         assert command.frame == mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT
         assert command.command == mavutil.mavlink.MAV_CMD_NAV_SPLINE_WAYPOINT
         assert command.param1 == 0


### PR DESCRIPTION
New PR for moving some modules that interface with dronekit instance into flightcontroller functions.

Migrates: connection_check.py, modules/add_takeoff_and_landing_command.py, modules/add_takeoff_and_loiter_command.py, modules/add_takeoff_and_rtl_command.py, modules/advanced_csv_to_commands.py, tests/unit/test_advanced_csv_to_commands.py, tests/unit/test_waypoints_to_commands.py, and tests/unit/test_waypoints_to_spline_commands.py